### PR TITLE
Re-enabled local testing in GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,8 +47,8 @@ jobs:
       #     export_default_credentials: true
       - name: Install dependencies
         run: make install
-      # - name: Test the API
-      #   run: make test
+      - name: Test the API
+        run: make test
       #   env:
       #     POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
       #     POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN }}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Re-enabled local testing in GitHub Actions


### PR DESCRIPTION
This may fail due to it purposely leaving out environment variables for the time being. Fixes #24.