### PR TITLE
Test for malformed and missing auth token

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Added tests for malformed and missing auth tokens

--- a/tests/python/test_auth.py
+++ b/tests/python/test_auth.py
@@ -1,0 +1,34 @@
+import os
+from dotenv import load_dotenv
+from tests.python.utils import client
+
+load_dotenv()
+
+# Note that this does not test the passage of a functioning token;
+# that is already handled by test_liveness in another file
+
+
+def test_malformed_token(client):
+    """Test that a malformed token, when passed to the API, returns a 401"""
+    response = client.post(
+        "/us/calculate",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer garbage_token",
+        },
+        data=open(
+            "./tests/python/data/calculate_us_1_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+    )
+    assert response.status_code == 401
+
+
+def test_no_token(client):
+    """Test that API returns 401 when no token is passed"""
+    response = client.post(
+        "/us/calculate",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
Fixes #40. This PR adds tests for malformed and missing auth tokens, ensuring that they return a status code of 401. Note that the PR does not test for success when a properly formed token is passed, as that is already done in `test_liveness`.